### PR TITLE
feat: implement etl pipeline

### DIFF
--- a/conf/base/catalog.yml
+++ b/conf/base/catalog.yml
@@ -9,13 +9,17 @@ raccoon_labels:
   type: CachedDataset
   dataset:
     type: pandas.CSVDataset
-    filepath: "s3://raccoon-spotter/raccoons1/labels.csv"
+    filepath: s3://raccoon-spotter/raccoons1/labels.csv
     credentials: aws_access
 
 raccoon_data_array:
   type: raccoon_spotter.datasets.NPZArrayDataset
-  filepath: "data/02_intermediate/raccoon_data_array.npz"
+  filepath: data/02_intermediate/raccoon_data_array.npz
 
-resized_raccoon_data_array:
+preprocessed_raccoon_data_array:
   type: raccoon_spotter.datasets.NPZArrayDataset
-  filepath: "data/03_primary/resized_raccoon_data_array.npz"
+  filepath: data/03_primary/preprocessed_raccoon_data_array.npz
+
+raccoon_features_data_array:
+  type: raccoon_spotter.datasets.NPZArrayDataset
+  filepath: "data/04_feature/raccoon_features_data_array.npz"

--- a/conf/base/parameters_data_processing.yml
+++ b/conf/base/parameters_data_processing.yml
@@ -1,3 +1,4 @@
-resize_image:
-  target_height: 400
-  target_width: 600
+padding: true
+padded_shape:
+  height: 400
+  width: 600

--- a/src/raccoon_spotter/datasets/npz_arrays.py
+++ b/src/raccoon_spotter/datasets/npz_arrays.py
@@ -8,11 +8,11 @@ from kedro.io.core import get_filepath_str, get_protocol_and_path
 
 
 class NPZArrayDataset(AbstractDataset):
-    def __init__(self, filepath: str):
+    def __init__(self, filepath: str, credentials: dict = {}):
         protocol, path = get_protocol_and_path(filepath)
         self._protocol = protocol
         self._filepath = PurePosixPath(path)
-        self._fs = fsspec.filesystem(self._protocol)
+        self._fs = fsspec.filesystem(self._protocol, **credentials.copy())
 
     def _load(self) -> Dict[str, np.ndarray]:
         load_path = get_filepath_str(self._filepath, self._protocol)

--- a/src/raccoon_spotter/pipeline_registry.py
+++ b/src/raccoon_spotter/pipeline_registry.py
@@ -1,4 +1,5 @@
 """Project pipelines."""
+
 from typing import Dict
 
 from kedro.framework.project import find_pipelines
@@ -13,4 +14,9 @@ def register_pipelines() -> Dict[str, Pipeline]:
     """
     pipelines = find_pipelines()
     pipelines["__default__"] = sum(pipelines.values())
+    pipelines["etl"] = (
+        pipelines["data_loading"]
+        + pipelines["data_processing"]
+        + pipelines["feature_extraction"]
+    )
     return pipelines

--- a/src/raccoon_spotter/pipelines/data_processing/nodes.py
+++ b/src/raccoon_spotter/pipelines/data_processing/nodes.py
@@ -4,7 +4,7 @@ import cv2
 import numpy as np
 
 
-def reshape_image_arrays(image_arrays: np.ndarray) -> Dict[str, np.ndarray]:
+def add_rgb_channel_to_image_arrays(image_arrays: np.ndarray) -> Dict[str, np.ndarray]:
     """
     Add a color channel for greyscale images.
 
@@ -49,26 +49,29 @@ def _letterbox_image(img, inp_dim):
     return canvas, pad_x, pad_y, scale
 
 
-def resize_image_arrays(
-    resize_image_config: dict, image_array: np.ndarray
+def pad_image_arrays(
+    image_arrays: np.ndarray, padded_shape: dict, padding: bool
 ) -> Dict[str, np.ndarray]:
     """
     Resize the image while adjusting the corresponding bounding box.
 
     Args:
-    - image_array (np.ndarray): The image array to be resized.
-    - target_width (int): The target width for resizing (default: 600).
-    - target_height (int): The target height for resizing (default: 400).
+    - image_arrays (np.ndarray): The image array to be resized.
+    - width (int): The target width for resizing (default: 600).
+    - height (int): The target height for resizing (default: 400).
 
     Returns:
      - A dictionary containing x (resized image array) and y (adjusted labels).
     """
+    if not padding:
+        return image_arrays
+
     resized_arrays = []
     pad_x_y = []
-    target_width = resize_image_config["target_width"]
-    target_height = resize_image_config["target_height"]
+    target_width = padded_shape["width"]
+    target_height = padded_shape["height"]
 
-    for img in image_array["x"]:
+    for img in image_arrays["x"]:
         resized_img, pad_x, pad_y, scale = _letterbox_image(
             img, (target_width, target_height)
         )
@@ -76,7 +79,7 @@ def resize_image_arrays(
         pad_x_y.append((pad_x, pad_y, scale))
 
     resized_boxes = []
-    for bbox, (pad_x, pad_y, scale) in zip(image_array["y"], pad_x_y):
+    for bbox, (pad_x, pad_y, scale) in zip(image_arrays["y"], pad_x_y):
         resized_bbox = [
             int((bbox[0] * scale) + pad_x),
             int((bbox[1] * scale) + pad_x),

--- a/src/raccoon_spotter/pipelines/data_processing/pipeline.py
+++ b/src/raccoon_spotter/pipelines/data_processing/pipeline.py
@@ -1,22 +1,26 @@
 from kedro.pipeline import Pipeline, node, pipeline
 
-from .nodes import reshape_image_arrays, resize_image_arrays
+from .nodes import add_rgb_channel_to_image_arrays, pad_image_arrays
 
 
 def create_pipeline(**kwargs) -> Pipeline:
     return pipeline(
         [
             node(
-                func=reshape_image_arrays,
+                func=add_rgb_channel_to_image_arrays,
                 inputs=["raccoon_data_array"],
-                outputs="reshaped_raccoon_data_array",
-                name="reshape_data_array_node",
+                outputs="rgb_raccoon_data_array",
+                name="add_rgb_channel_node",
             ),
             node(
-                func=resize_image_arrays,
-                inputs=["params:resize_image", "reshaped_raccoon_data_array"],
-                outputs="resized_raccoon_data_array",
-                name="resize_data_array_node",
+                func=pad_image_arrays,
+                inputs=[
+                    "rgb_raccoon_data_array",
+                    "params:padded_shape",
+                    "params:padding",
+                ],
+                outputs="preprocessed_raccoon_data_array",
+                name="apply_padding_node",
             ),
         ]
     )

--- a/src/raccoon_spotter/pipelines/feature_extraction/__init__.py
+++ b/src/raccoon_spotter/pipelines/feature_extraction/__init__.py
@@ -1,0 +1,3 @@
+"""Raccoon data processing pipeline"""
+
+from .pipeline import create_pipeline  # NOQA

--- a/src/raccoon_spotter/pipelines/feature_extraction/pipeline.py
+++ b/src/raccoon_spotter/pipelines/feature_extraction/pipeline.py
@@ -1,0 +1,14 @@
+from kedro.pipeline import Pipeline, node, pipeline
+
+
+def create_pipeline(**kwargs) -> Pipeline:
+    return pipeline(
+        [
+            node(
+                func=lambda x: x,
+                inputs=["preprocessed_raccoon_data_array"],
+                outputs="raccoon_features_data_array",
+                name="identity",
+            ),
+        ]
+    )

--- a/src/tests/pipelines/test_data_processing.py
+++ b/src/tests/pipelines/test_data_processing.py
@@ -1,8 +1,8 @@
 import numpy as np
 import pytest
 from raccoon_spotter.pipelines.data_processing.nodes import (
-    reshape_image_arrays,
-    resize_image_arrays,
+    add_rgb_channel_to_image_arrays,
+    pad_image_arrays,
 )
 
 dummy_image_arrays = {
@@ -18,8 +18,8 @@ num_img = len(dummy_image_arrays["x"])
 
 
 @pytest.fixture
-def test_reshape_image_arrays():
-    reshaped_dict = reshape_image_arrays(dummy_image_arrays)
+def test_add_rgb_channel_to_image_arrays():
+    reshaped_dict = add_rgb_channel_to_image_arrays(dummy_image_arrays)
     assert isinstance(reshaped_dict, dict)
     assert "x" in reshaped_dict
     assert "y" in reshaped_dict
@@ -30,8 +30,8 @@ def test_reshape_image_arrays():
 
 
 @pytest.fixture
-def test_resize_image_arrays():
-    resized_dict = resize_image_arrays(dummy_image_arrays, dummy_image_arrays)
+def test_pad_image_arrays():
+    resized_dict = pad_image_arrays(dummy_image_arrays, dummy_image_arrays)
     assert isinstance(resized_dict, dict)
     assert "x" in resized_dict
     assert "y" in resized_dict


### PR DESCRIPTION
1. Addition of an etl (extract transform load) pipeline that can now be invoked with `kedro run --pipeline etl`.
2. Some reorganization of node and datasets naming and signatures conventions.
3. Creation of an empty feature extractor.
4. Padding is now optional.