### PR TITLE
refactor: move install-deps.sh into github worflow file

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,0 +1,16 @@
+name: Setup project environment
+
+runs:
+  using: composite
+  steps:
+  - name: Set up Python 3.10
+    uses: actions/setup-python@v5
+    with:
+      python-version: '3.10'
+      cache: 'pipenv'
+  - name: Install dependencies
+    shell: bash
+    run: |
+      python -m pip install --upgrade pip
+      pip install --user pipenv
+      pipenv install --dev

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -12,14 +12,8 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - name: Set up Python 3.10
-      uses: actions/setup-python@v5
-      with:
-        python-version: '3.10'
-        cache: 'pipenv'
-    - name: Install dependencies
-      run: bash scripts/install-deps.sh
+    - uses: actions/checkout@v3
+    - uses: ./.github/actions/setup
     - name: Run ruff linter
       run: pipenv run ruff check $(git ls-files '*.py') --show-files
 
@@ -27,13 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python 3.10
-      uses: actions/setup-python@v5
-      with:
-        python-version: '3.10'
-        cache: 'pipenv'
-    - name: Install dependencies
-      run: bash scripts/install-deps.sh
+    - uses: ./.github/actions/setup
     - name: Run tests
       run: pipenv run pytest
 
@@ -41,15 +29,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: [lint, test]
     steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v4
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.10'
-          cache: 'pipenv'
-      - name: Install dependencies
-        run: bash scripts/install-deps.sh
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup
       - name: Package project
         run: |
           pipenv requirements --exclude-markers | tail -n +2 > requirements.txt

--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-python -m pip install --upgrade pip
-pip install --user pipenv
-pipenv install --dev


### PR DESCRIPTION
Installation of required python packages done via `scripts/install-deps.sh` is now fully contained within the github workflows.