### PR TITLE
refactor: move repeated dataset code into an intermediate class

### DIFF
--- a/src/raccoon_spotter/datasets/abstract_filesystem.py
+++ b/src/raccoon_spotter/datasets/abstract_filesystem.py
@@ -1,0 +1,24 @@
+import abc
+from pathlib import PurePosixPath
+from typing import Any, Dict, Generic
+
+import fsspec
+from kedro.io import AbstractDataset
+from kedro.io.core import _DI, _DO, get_filepath_str, get_protocol_and_path
+
+
+class AbstractFileSystemDataset(AbstractDataset, abc.ABC, Generic[_DI, _DO]):
+    def __init__(self, filepath: str, fsspec_kwargs: dict = {}):
+        protocol, path = get_protocol_and_path(filepath)
+        self._protocol = protocol
+        self._filepath = PurePosixPath(path)
+        self._fs = fsspec.filesystem(self._protocol, **fsspec_kwargs.copy())
+
+    def _get_filepath_str(self):
+        return get_filepath_str(self._filepath, self._protocol)
+
+    def _describe(self) -> Dict[str, Any]:
+        return dict(
+            filepath=self._filepath,
+            protocol=self._protocol,
+        )

--- a/src/raccoon_spotter/datasets/keras_model.py
+++ b/src/raccoon_spotter/datasets/keras_model.py
@@ -1,28 +1,23 @@
-from pathlib import PurePosixPath
 from typing import Any, Dict
 
-import fsspec
 import keras
-from kedro.io import AbstractDataset
-from kedro.io.core import get_filepath_str, get_protocol_and_path
+
+from .abstract_filesystem import AbstractFileSystemDataset
 
 
-class KerasModelDataset(AbstractDataset[keras.Model, keras.Model]):
+class KerasModelDataset(AbstractFileSystemDataset[keras.Model, keras.Model]):
     def __init__(self, filepath: str, custom_components: Dict[str, Any] = {}):
-        protocol, path = get_protocol_and_path(filepath)
-        self._protocol = protocol
-        self._filepath = PurePosixPath(path)
+        super().__init__(filepath)
         self._custom_components = custom_components
-        self._fs = fsspec.filesystem(self._protocol)
 
     def _load(self) -> keras.Model:
-        load_path = get_filepath_str(self._filepath, self._protocol)
+        load_path = self._get_filepath_str()
         return keras.models.load_model(
             load_path, custom_objects=self._custom_components
         )
 
     def _save(self, model: keras.Model) -> None:
-        save_path = get_filepath_str(self._filepath, self._protocol)
+        save_path = self._get_filepath_str()
         model.save(save_path)
 
     def _describe(self) -> Dict[str, Any]:

--- a/src/raccoon_spotter/datasets/npz_arrays.py
+++ b/src/raccoon_spotter/datasets/npz_arrays.py
@@ -1,25 +1,20 @@
-from pathlib import PurePosixPath
 from typing import Any, Dict
 
-import fsspec
 import numpy as np
-from kedro.io import AbstractDataset
-from kedro.io.core import get_filepath_str, get_protocol_and_path
+
+from .abstract_filesystem import AbstractFileSystemDataset
 
 
-class NPZArrayDataset(AbstractDataset):
+class NPZArrayDataset(AbstractFileSystemDataset[np.ndarray, np.ndarray]):
     def __init__(self, filepath: str, credentials: dict = {}):
-        protocol, path = get_protocol_and_path(filepath)
-        self._protocol = protocol
-        self._filepath = PurePosixPath(path)
-        self._fs = fsspec.filesystem(self._protocol, **credentials.copy())
+        super().__init__(filepath, fsspec_kwargs=credentials)
 
     def _load(self) -> Dict[str, np.ndarray]:
-        load_path = get_filepath_str(self._filepath, self._protocol)
+        load_path = self._get_filepath_str()
         return np.load(load_path, allow_pickle=True)
 
     def _save(self, data: Dict[str, np.array]) -> None:
-        save_path = get_filepath_str(self._filepath, self._protocol)
+        save_path = self._get_filepath_str()
         np.savez(save_path, **data)
 
     def _describe(self) -> Dict[str, Any]:

--- a/src/raccoon_spotter/datasets/zipped_images.py
+++ b/src/raccoon_spotter/datasets/zipped_images.py
@@ -1,24 +1,19 @@
-from pathlib import PurePosixPath
 from typing import Any, Dict
 from zipfile import ZipFile
 
-import fsspec
 import numpy as np
-from kedro.io import AbstractDataset
-from kedro.io.core import get_filepath_str, get_protocol_and_path
 from PIL import Image
 
+from .abstract_filesystem import AbstractFileSystemDataset
 
-class ZippedImagesDataset(AbstractDataset[np.ndarray, np.ndarray]):
+
+class ZippedImagesDataset(AbstractFileSystemDataset[np.ndarray, np.ndarray]):
     def __init__(self, filepath: str, credentials: dict, extension: str = ".jpg"):
-        protocol, path = get_protocol_and_path(filepath)
-        self._protocol = protocol
-        self._filepath = PurePosixPath(path)
-        self._fs = fsspec.filesystem(self._protocol, **credentials.copy())
+        super().__init__(filepath, fsspec_kwargs=credentials)
         self._ext = extension
 
     def _load(self) -> Dict[str, np.array]:
-        load_path = get_filepath_str(self._filepath, self._protocol)
+        load_path = self._get_filepath_str()
         with self._fs.open(load_path, mode="rb") as file:
             with ZipFile(file, "r") as zipped:
                 return {


### PR DESCRIPTION
The original dataset implementations share most of the code which is now separated and made into an abstract class that the other datasets can inherit from.